### PR TITLE
Support directory shorthand for wider range of spec files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,10 +168,7 @@ fn bindle_build_args<'a>(requirements: BindleBuildRequirements) -> Vec<Arg<'a>> 
 /// - ARG_OUTPUT
 /// - ARG_BINDLE_URL
 async fn prepare(args: &ArgMatches) -> anyhow::Result<()> {
-    let source = args
-        .value_of(ARG_HIPPOFACTS)
-        .ok_or_else(|| anyhow::Error::msg("HIPPOFACTS file is required"))
-        .and_then(sourcedir)?;
+    let source = hippofacts_file_path_from_args(args)?;
 
     let current_dir = std::env::current_dir()?;
     let destination = args
@@ -208,10 +205,7 @@ async fn prepare(args: &ArgMatches) -> anyhow::Result<()> {
 /// - ARG_OUTPUT
 /// - ARG_BINDLE_URL
 async fn bindle(args: &ArgMatches) -> anyhow::Result<()> {
-    let source = args
-        .value_of(ARG_HIPPOFACTS)
-        .ok_or_else(|| anyhow::Error::msg("HIPPOFACTS file is required"))
-        .and_then(sourcedir)?;
+    let source = hippofacts_file_path_from_args(args)?;
 
     let destination = match args.value_of(ARG_STAGING_DIR) {
         Some(dir) => std::env::current_dir()?.join(dir),
@@ -241,10 +235,7 @@ async fn bindle(args: &ArgMatches) -> anyhow::Result<()> {
 
 /// Package a bindle and push it to a Bindle server, notifying Hippo.
 async fn push(args: &ArgMatches) -> anyhow::Result<()> {
-    let hippofacts_arg = args
-        .value_of(ARG_HIPPOFACTS)
-        .ok_or_else(|| anyhow::Error::msg("HIPPOFACTS file is required"))?;
-    let source = sourcedir(hippofacts_arg)?;
+    let source = hippofacts_file_path_from_args(args)?;
 
     // Local configuration
     let versioning_arg = args.value_of(ARG_VERSIONING).unwrap();
@@ -382,8 +373,13 @@ fn external_bindle_id(entry: &HippoFactsEntry) -> Option<bindle::Id> {
     entry.external_ref().map(|ext| ext.bindle_id)
 }
 
-/// Find the source directory
-fn sourcedir(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
+fn hippofacts_file_path_from_args(args: &ArgMatches) -> anyhow::Result<PathBuf> {
+    args.value_of(ARG_HIPPOFACTS)
+        .ok_or_else(|| anyhow::Error::msg("HIPPOFACTS file is required"))
+        .and_then(hippofacts_file_path)
+}
+
+fn hippofacts_file_path(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
     let source_file_or_dir = std::env::current_dir()?.join(hippofacts_arg);
     let source = if source_file_or_dir.is_file() {
         source_file_or_dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,13 +380,21 @@ fn hippofacts_file_path_from_args(args: &ArgMatches) -> anyhow::Result<PathBuf> 
 }
 
 fn hippofacts_file_path(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
-    let source_file_or_dir = std::env::current_dir()?.join(hippofacts_arg);
-    let source = if source_file_or_dir.is_file() {
-        source_file_or_dir
+    let source = std::env::current_dir()?.join(hippofacts_arg);
+    if source.is_dir() {
+        find_hippofacts_file_in(&source)
+    } else if source.is_file() {
+        Ok(source)
     } else {
-        source_file_or_dir.join("HIPPOFACTS")
-    };
+        Err(anyhow::anyhow!(
+            "Artifacts spec not found: file {} does not exist",
+            source.to_string_lossy()
+        ))
+    }
+}
 
+fn find_hippofacts_file_in(source_dir: &PathBuf) -> anyhow::Result<PathBuf> {
+    let source = source_dir.join("HIPPOFACTS");
     if !source.exists() {
         return Err(anyhow::anyhow!(
             "Artifacts spec not found: file {} does not exist",

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,15 +393,22 @@ fn hippofacts_file_path(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
     }
 }
 
+const SPEC_FILENAMES: &[&str] = &[
+    "HIPPOFACTS", "hippofacts", "Hippofacts",
+    "HIPPOFACTS.toml", "hippofacts.toml", "Hippofacts.toml"
+];
+
 fn find_hippofacts_file_in(source_dir: &PathBuf) -> anyhow::Result<PathBuf> {
-    let source = source_dir.join("HIPPOFACTS");
-    if !source.exists() {
-        return Err(anyhow::anyhow!(
-            "Artifacts spec not found: file {} does not exist",
-            source.to_string_lossy()
-        ));
+    for filename in SPEC_FILENAMES {
+        let source = source_dir.join(filename);
+        if source.is_file() {
+            return Ok(source);
+        }
     }
-    Ok(source)
+    return Err(anyhow::anyhow!(
+        "No artifacts spec not found in directory {}: create a HIPPOFACTS file",
+        source_dir.to_string_lossy()
+    ));
 }
 
 /// Describe the desired output format.


### PR DESCRIPTION
This PR enables users to use directory shorthand on a wider range of spec files.  Currently, if you want to use directory shorthand (`hippo push .`) you have to call your spec file `HIPPOFACTS`.  Although simple and hopefully memorable, this:

1. Is shouty. Users might prefer to reserve shouty names for README and LICENSE and CHANGELOG and CODE_OF_CONDUCT and er anyway enough shouting already.
2. Doesn't support syntax highlighting*.  The VS Code TOML extension won't recognise it without the `.toml` file extension.

*Yet.

You have always been able to have non-shouting spec files but have had to write `hippo push ./hippofacts.toml` or whatever to use them.  With this PR, the directory shorthand `hippo push .` will now accept any of `HIPPOFACTS`, `Hippofacts`, `hippofacts`, or their equivalents with the `.toml` extension.

**Reviewers:** Is this a good idea or is it just going to sow confusion and uncertainty?

~TODO: If the user uses directory shorthand, and more than one matching file exists, we should fail rather than picking the one from our arbitrary order - otherwise the user may work on `hippofacts.toml` and not realise that we are actually pushing `Hippofacts`.~