### PR TITLE
Hide password value in help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ async fn main() -> anyhow::Result<()> {
                 .arg(
                     Arg::new(ARG_HIPPO_PASSWORD)
                         .required(true)
+                        .hide_env_values(true)
                         .long("hippo-password")
                         .env("HIPPO_PASSWORD")
                         .about("The password for connecting to Hippo"),


### PR DESCRIPTION
Fixes #59.

```
12:44 $ ./target/debug/hippo help push
# ... elided ...
OPTIONS:
    -s, --server <bindle_server>
            The Bindle server to push the artifacts to [env:
            BINDLE_URL=https://bindle.f1sh.ca:8080/v1]

        --hippo-password <hippo_password>
            The password for connecting to Hippo [env: HIPPO_PASSWORD]

        --hippo-url <hippo_url>
            The Hippo service to push the artifacts to [env: HIPPO_URL=https://hippo.f1sh.ca/]
```

If there's a better way, or if you don't like this output, let me know!