### PR TITLE
Fix spec file inference on case-insensitive file systems

### DIFF
--- a/src/command/upload.rs
+++ b/src/command/upload.rs
@@ -372,7 +372,23 @@ fn hippofacts_file_path(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
     }
 }
 
+// The list of filenames to look for has to take case sensitivity
+// into account.
+#[cfg(target_os = "windows")]
 const SPEC_FILENAMES: &[&str] = &["HIPPOFACTS", "hippofacts.toml"];
+// TODO: apparently there is a config option to make Mac filesystems
+// case sensitive; fml.
+#[cfg(target_os = "macos")]
+const SPEC_FILENAMES: &[&str] = &["HIPPOFACTS", "hippofacts.toml"];
+#[cfg(target_os = "linux")]
+const SPEC_FILENAMES: &[&str] = &[
+    "HIPPOFACTS",
+    "hippofacts",
+    "Hippofacts",
+    "HIPPOFACTS.toml",
+    "hippofacts.toml",
+    "Hippofacts.toml",
+];
 
 fn find_hippofacts_file_in(source_dir: &Path) -> anyhow::Result<PathBuf> {
     let candidates = SPEC_FILENAMES

--- a/src/command/upload.rs
+++ b/src/command/upload.rs
@@ -372,14 +372,7 @@ fn hippofacts_file_path(hippofacts_arg: &str) -> anyhow::Result<PathBuf> {
     }
 }
 
-const SPEC_FILENAMES: &[&str] = &[
-    "HIPPOFACTS",
-    "hippofacts",
-    "Hippofacts",
-    "HIPPOFACTS.toml",
-    "hippofacts.toml",
-    "Hippofacts.toml",
-];
+const SPEC_FILENAMES: &[&str] = &["HIPPOFACTS", "hippofacts.toml"];
 
 fn find_hippofacts_file_in(source_dir: &Path) -> anyhow::Result<PathBuf> {
     let candidates = SPEC_FILENAMES

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,5 +49,3 @@ async fn main() -> anyhow::Result<()> {
         _ => Err(anyhow::anyhow!("No matching command. Try 'hippo help'")),
     }
 }
-
-//


### PR DESCRIPTION
This is as per #70 but takes the case sensitivity of the file system into account.  (Sorry, Adam, I based this off your work but messed up trying to amend it in your PR.)