### PR TITLE
Show invoice name when external ref fails

### DIFF
--- a/src/command/upload.rs
+++ b/src/command/upload.rs
@@ -353,7 +353,9 @@ async fn prefetch_required_invoices(
         .client()?;
 
     for external_ref in external_refs {
-        let invoice = client.get_yanked_invoice(&external_ref).await?;
+        let invoice = client.get_yanked_invoice(&external_ref)
+            .await
+            .map_err(|e| anyhow::anyhow!("Error retrieving external reference {}: {}", external_ref, e))?;
         map.insert(external_ref, invoice);
     }
 


### PR DESCRIPTION
Fixes #78.

Now shows `Error: Error retrieving external reference fileserver/0.4.0: Invoice was not found`. It's not going to win the Nobel Prize for Error Messages but hopefully at least points people in the right direction.