### PR TITLE
fix(src/expander.rs): update prerelease logic in mangle_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +662,7 @@ dependencies = [
  "hippo 0.1.0",
  "itertools",
  "mime_guess",
+ "regex",
  "reqwest",
  "semver",
  "serde",
@@ -1312,6 +1322,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ glob = "0.3.0"
 hippo = { git = "https://github.com/deislabs/hippo-client-rust", branch = "main" }
 itertools = "0.10.0"
 mime_guess = { version = "2.0" }
+regex = "1.5.4"
 reqwest = { version = "0.11", features = ["stream"] }
 semver = { version = "0.11", features = ["serde"] }
 serde = {version = "1.0", features = ["derive"]}

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -41,7 +41,7 @@ impl ExpansionContext {
                     .map(|s| format!("-{}", s))
                     .unwrap_or_else(|| "".to_owned());
                 let timestamp = chrono::Local::now()
-                    .format("-%Y.%m.%d.%H.%M.%S.%3f")
+                    .format("-%Y%m%d%H%M%S%3f")
                     .to_string();
                 format!("{}{}{}", version, user, timestamp)
             }
@@ -557,6 +557,7 @@ impl WagiFeatureProvider for Export {
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
+    use semver::Version;
 
     use super::*;
 
@@ -769,6 +770,14 @@ mod test {
     fn test_name_is_kept() {
         let invoice = expand_test_invoice("app1").unwrap();
         assert_eq!("weather", invoice.bindle.id.name());
+    }
+
+    #[test]
+    fn test_version_is_valid_semver() {
+        let invoice = expand_test_invoice("app1").unwrap();
+        assert!(
+            Version::parse(&invoice.bindle.id.version().to_string()).is_ok()
+        );
     }
 
     #[test]

--- a/testdata/bad_version/HIPPOFACTS
+++ b/testdata/bad_version/HIPPOFACTS
@@ -1,0 +1,7 @@
+[bindle]
+name = "bad_version"
+version = "1.2.3.4"
+
+[[handler]]
+name = "out/fake.wasm"
+route = "/fake"

--- a/testdata/bad_version/out/fake.wasm
+++ b/testdata/bad_version/out/fake.wasm
@@ -1,0 +1,1 @@
+Supposedly Wasm but not really


### PR DESCRIPTION
* Update prerelease (timestamp) logic in mangle_version to avoid [instances of semver incompliance](https://github.com/deislabs/hippo-cli/issues/91)

Notes for reviewers: Please advise on testing strategy -- fairly new to rust and certainly new to the test structure for this project, so not sure if my addition is ideal or not (including better/different uses of assert* libraries, etc).  Thanks!

Fixes https://github.com/deislabs/hippo-cli/issues/91