### PR TITLE
implement `bindle login/logout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,27 +247,36 @@ assemble all matching files and publish them as a bindle. In this mode,
 * Pushes to the Bindle server
 * Notifies Hippo that a new bindle version is available
 
-The Bindle server is specified in the `BINDLE_URL` environment variable.
-(If you don't want to set the environment variable, pass the `-s` argument with the URL.)
-If the Bindle server requires authentication, specify this via the `BINDLE_USERNAME`
-and `BINDLE_PASSWORD` environment variables (or `--bindle-username` and `--bindle-password`
-options). Note that Bindle authentication is independent of Hippo authentication!
+Authentication is handled through two commands:
 
-The Hippo URL is specified in the `HIPPO_URL` environment variable. Hippo
-requires authentication: pass the username in `HIPPO_USERNAME` and the password in
-`HIPPO_PASSWORD`. (The equivalent command line options are `--hippo-url`, `--hippo-username`
-and `--hippo-password`.)
+- `hippo auth login`, which logs into Hippo
+- `hippo bindle login`, which logs into Bindle
 
-If you want to review the proposed bindle rather than pushing it, pass `hippo prepare -d <staging_dir> .`.
-This will stage the bindle to the specified directory but _not_ push it. If you want to push the
-generated bindle but not notify Hippo, use `hippo bindle .`.
+With `hippo auth login`, the Hippo URL is specified in the `--url` flag. Hippo requires authentication:
+if `--username` or `--password` are not provided, the CLI will prompt for that information.
+
+With `hippo bindle login`, the Bindle server is specified with the `--url` flag. If the Bindle server
+requires authentication, specify this via the `--username` and `--password` options. Note that Bindle
+authentication is independent of Hippo authentication, and in some cases (e.g. if `bindle-server` is
+provided the `--unauthenticated` flag), no authentication is necessary!
+
+If you want to review the proposed bindle rather than pushing it, pass
+`hippo bindle prepare -d <staging_dir> .`. This will stage the bindle to the specified directory but
+_not_ push it. If you want to push the generated bindle but not notify Hippo, use
+`hippo bindle push .`.
 
 In a CI environment you can supply the `-v production` option to suppress version mangling.
 This will create and upload the bindle with the version from `HIPPOFACTS`, without the
 prerelease segment.
 
-If you want to skip server verification, pass the `-k` flag. This can be useful if you are running
-development services with self-signed certificates. **This is a security risk: do not use it in production.**
+If you want to skip server TLS verification, pass the `-k` flag to either `login` command. This can be
+useful if you are running development services with self-signed certificates.
+**This is a security risk: do not use it in production.**
+
+Logging out can be performed with
+
+- `hippo auth logout`, which logs out of Hippo
+- `hippo bindle logout`, which logs out of Bindle
 
 ## Building from source
 

--- a/src/cli/commands/auth.rs
+++ b/src/cli/commands/auth.rs
@@ -14,36 +14,27 @@ pub(crate) enum Commands {
         #[clap(long)]
         password: Option<String>,
         /// Should invalid TLS certificates be accepted by the client?
-        #[clap(long)]
+        #[clap(short = 'k', long)]
         danger_accept_invalid_certs: bool,
     },
 
     /// Log into Hippo
     Login {
-        /// The URL to log into Bindle
-        #[clap(long, default_value = "http://localhost:8080/v1")]
-        bindle_url: String,
-        /// The username to log into Bindle
-        #[clap(long)]
-        bindle_username: Option<String>,
-        /// The password to log into Bindle
-        #[clap(long)]
-        bindle_password: Option<String>,
         /// The URL to log into Hippo
         #[clap(long, default_value = "https://localhost:5309")]
-        hippo_url: String,
+        url: String,
         /// The username to log into Hippo
         #[clap(long)]
-        hippo_username: Option<String>,
+        username: Option<String>,
         /// The password to log into Hippo
         #[clap(long)]
-        hippo_password: Option<String>,
+        password: Option<String>,
         /// Should invalid TLS certificates be accepted by the client?
-        #[clap(long)]
+        #[clap(short = 'k', long)]
         danger_accept_invalid_certs: bool,
     },
 
-    /// End the current login session
+    /// End the current Hippo login session
     Logout {},
 
     /// prints the logged in user

--- a/src/cli/commands/bindle.rs
+++ b/src/cli/commands/bindle.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub(crate) enum Commands {
+    /// Prepare a bindle, but write it to disk instead of sending it over the network
+    Prepare {
+        /// The artifacts spec (file or directory containing HIPPOFACTS file)
+        #[clap(parse(from_os_str), default_value = ".")]
+        path: PathBuf,
+
+        /// How to version the generated invoice
+        #[clap(
+            short = 'v',
+            long,
+            default_value = "development",
+            possible_values(super::INVOICE_VERSION_ACCEPTED_VALUES)
+        )]
+        invoice_version: String,
+
+        /// Where should the bindle be written to
+        #[clap(short, long, parse(from_os_str), default_value = ".hippo")]
+        destination: PathBuf,
+    },
+
+    /// Package and upload Hippo artifacts without notifying Hippo
+    Push {
+        /// The artifacts spec (file or directory containing HIPPOFACTS file)
+        #[clap(parse(from_os_str), default_value = ".")]
+        path: PathBuf,
+
+        /// How to version the generated invoice
+        #[clap(
+            short = 'v',
+            long,
+            default_value = "development",
+            possible_values(super::INVOICE_VERSION_ACCEPTED_VALUES)
+        )]
+        invoice_version: String,
+    },
+    /// Log into Bindle
+    Login {
+        /// The URL to log into Bindle
+        #[clap(long, default_value = "http://localhost:8080/v1")]
+        url: String,
+        /// The username to log into Bindle
+        #[clap(long)]
+        username: Option<String>,
+        /// The password to log into Bindle
+        #[clap(long)]
+        password: Option<String>,
+        /// Should invalid TLS certificates be accepted by the client?
+        #[clap(short = 'k', long)]
+        danger_accept_invalid_certs: bool,
+    },
+
+    /// End the current Bindle login session
+    Logout {},
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod app;
 pub(crate) mod auth;
+pub(crate) mod bindle;
 pub(crate) mod certificate;
 pub(crate) mod channel;
 pub(crate) mod environment_variable;
@@ -21,6 +22,10 @@ pub(crate) enum Commands {
     #[clap(subcommand)]
     Auth(auth::Commands),
 
+    /// Register new accounts and log in/out of Hippo
+    #[clap(subcommand)]
+    Bindle(bindle::Commands),
+
     /// Add, update, and remove TLS Certificate
     #[clap(subcommand)]
     Certificate(certificate::Commands),
@@ -40,44 +45,6 @@ pub(crate) enum Commands {
     /// Add and remove revisions
     #[clap(subcommand)]
     Revision(revision::Commands),
-
-    /// Package and upload Hippo artifacts without notifying Hippo
-    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
-    Bindle {
-        /// The artifacts spec (file or directory containing HIPPOFACTS file)
-        #[clap(parse(from_os_str), default_value = ".")]
-        path: PathBuf,
-
-        /// How to version the generated invoice
-        #[clap(
-            short = 'v',
-            long,
-            default_value = "development",
-            possible_values(INVOICE_VERSION_ACCEPTED_VALUES)
-        )]
-        invoice_version: String,
-    },
-
-    /// Prepare a bindle, but write it to disk instead of sending it over the network
-    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
-    Prepare {
-        /// The artifacts spec (file or directory containing HIPPOFACTS file)
-        #[clap(parse(from_os_str), default_value = ".")]
-        path: PathBuf,
-
-        /// How to version the generated invoice
-        #[clap(
-            short = 'v',
-            long,
-            default_value = "development",
-            possible_values(INVOICE_VERSION_ACCEPTED_VALUES)
-        )]
-        invoice_version: String,
-
-        /// Where should the bindle be written to
-        #[clap(short, long, parse(from_os_str), default_value = ".hippo")]
-        destination: PathBuf,
-    },
 
     /// Package and upload Hippo artifacts, notifying Hippo
     #[clap(setting(AppSettings::ArgRequiredElseHelp))]


### PR DESCRIPTION
A couple of changes were introduced in this commit:

- hippo bindle -> hippo bindle push. This was required to free up the `hippo bindle` command as a subcommand tree.
- hippo prepare -> hippo bindle prepare (this can be reverted)
- hippo bindle login was introduced
- hippo bindle logout was introduced
- hippo auth login no longer logs you into bindle
- `--danger-accept-invalid-certs` now accepts the shortflag `-k` for compatibility
- bindle and hippo configuration is stored separately, in
  ~/.config/hippo/hippo.json and ~/.config/hippo/bindle.json,
  respectively

fixes #100

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>