### PR TITLE
bump version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hippo"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Ivan Towlson <ivan.towlson@fermyon.com>",
     "Matt Fisher <matt.fisher@fermyon.com>"


### PR DESCRIPTION
Hippo v0.10.0 currently reports that it is v0.9.0:

```
><> hippo --version
hippo 0.9.0
```

This will fix the issue when compiled from main. We should make sure to perform this step prior to releasing 0.11.0.