### PR TITLE
bump upload-artifact to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           zip -r hippo-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip README.md LICENSE hippo${{ matrix.config.extension }}
           shasum -a 256 *.tar.gz *.zip > checksums-${{ env.RELEASE_VERSION }}.txt
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
           name: hippo
           path: |


### PR DESCRIPTION
It appears that v2.1.0 introduced multiple upload path support: https://github.com/actions/upload-artifact/releases/tag/2.1.0

Bumping to v3 should fix this.
