### PR TITLE
remove zip

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,13 +56,11 @@ jobs:
           cp README.md LICENSE target/release/hippo${{ matrix.config.extension }} _dist/
           cd _dist
           tar czf hippo-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz README.md LICENSE hippo${{ matrix.config.extension }}
-          zip -r hippo-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip README.md LICENSE hippo${{ matrix.config.extension }}
-          shasum -a 256 *.tar.gz *.zip > checksums-${{ env.RELEASE_VERSION }}.txt
+          shasum -a 256 *.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
 
       - uses: actions/upload-artifact@v3
         with:
           name: hippo
           path: |
             _dist/hippo-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-            _dist/hippo-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
             _dist/checksums-${{ env.RELEASE_VERSION }}.txt


### PR DESCRIPTION
zip is not available on windows workers. Removing it for now.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>