### PR TITLE
introduce command aliases

### DIFF
--- a/src/cli/commands/app.rs
+++ b/src/cli/commands/app.rs
@@ -1,8 +1,11 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="a")]
+#[clap(alias ="apps")]
 pub(crate) enum Commands {
     /// Add an application
+    #[clap(alias ="new")]
     Add {
         /// The name of the application
         name: String,
@@ -10,6 +13,8 @@ pub(crate) enum Commands {
         storage_id: String,
     },
     /// Remove an application
+    #[clap(alias ="delete")]
+    #[clap(alias ="rm")]
     Remove {
         /// The application ID
         id: String,

--- a/src/cli/commands/bindle.rs
+++ b/src/cli/commands/bindle.rs
@@ -3,8 +3,10 @@ use std::path::PathBuf;
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="b")]
 pub(crate) enum Commands {
     /// Prepare a bindle, but write it to disk instead of sending it over the network
+    #[clap(alias ="prep")]
     Prepare {
         /// The artifacts spec (file or directory containing HIPPOFACTS file)
         #[clap(parse(from_os_str), default_value = ".")]
@@ -25,6 +27,7 @@ pub(crate) enum Commands {
     },
 
     /// Package and upload Hippo artifacts without notifying Hippo
+    #[clap(alias ="p")]
     Push {
         /// The artifacts spec (file or directory containing HIPPOFACTS file)
         #[clap(parse(from_os_str), default_value = ".")]

--- a/src/cli/commands/certificate.rs
+++ b/src/cli/commands/certificate.rs
@@ -3,8 +3,12 @@ use std::path::PathBuf;
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="cert")]
+#[clap(alias ="certs")]
+#[clap(alias ="certificates")]
 pub(crate) enum Commands {
     /// Add a TLS certificate
+    #[clap(alias ="new")]
     Add {
         /// The name of the certificate
         name: String,
@@ -16,6 +20,8 @@ pub(crate) enum Commands {
         private_key_path: PathBuf,
     },
     /// Remove a TLS certificate
+    #[clap(alias ="delete")]
+    #[clap(alias ="rm")]
     Remove {
         /// The certificate ID
         id: String,

--- a/src/cli/commands/channel.rs
+++ b/src/cli/commands/channel.rs
@@ -1,8 +1,11 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="c")]
+#[clap(alias ="channels")]
 pub(crate) enum Commands {
     /// Add a channel
+    #[clap(alias ="new")]
     Add {
         /// The name of the channel
         name: String,
@@ -27,6 +30,8 @@ pub(crate) enum Commands {
         certificate_id: Option<String>,
     },
     /// Remove a channel
+    #[clap(alias ="delete")]
+    #[clap(alias ="rm")]
     Remove {
         /// The channel ID
         id: String,

--- a/src/cli/commands/environment_variable.rs
+++ b/src/cli/commands/environment_variable.rs
@@ -1,8 +1,14 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="e")]
+#[clap(alias ="envvar")]
+#[clap(alias ="envvars")]
+#[clap(alias ="environmentvariable")]
+#[clap(alias ="environmentvariables")]
 pub(crate) enum Commands {
     /// Add an environment variable
+    #[clap(alias ="new")]
     Add {
         /// The environment variable key
         key: String,
@@ -12,6 +18,8 @@ pub(crate) enum Commands {
         channel_id: String,
     },
     /// Remove an environment variable
+    #[clap(alias ="delete")]
+    #[clap(alias ="rm")]
     Remove {
         /// The environment variable ID
         id: String,

--- a/src/cli/commands/revision.rs
+++ b/src/cli/commands/revision.rs
@@ -1,8 +1,11 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+#[clap(alias ="r")]
+#[clap(alias ="revisions")]
 pub(crate) enum Commands {
     /// Add a revision
+    #[clap(alias ="new")]
     Add {
         /// The storage ID of the Bindle
         app_storage_id: String,


### PR DESCRIPTION
This introduces convenient shorthand aliases as well as plural aliases. You can now use `hippo app remove`, `hippo apps remove`, and `hippo a rm` interchangeably.