### PR TITLE
implement list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cargo build --release
 This project welcomes contributions and suggestions.  Most contributions require
 you to agree to a Contributor License Agreement (CLA) declaring that you have
 the right to, and actually do, grant us the rights to use your contribution. For
-details, visit https://cla.microsoft.com.
+details, visit <https://cla.microsoft.com>.
 
 When you submit a pull request, a CLA-bot will automatically determine whether
 you need to provide a CLA and decorate the PR appropriately (e.g., label,

--- a/src/cli/commands/app.rs
+++ b/src/cli/commands/app.rs
@@ -12,6 +12,10 @@ pub(crate) enum Commands {
         /// The Bindle ID where releases will be uploaded
         storage_id: String,
     },
+
+    // List all apps
+    List { },
+
     /// Remove an application
     #[clap(alias ="delete")]
     #[clap(alias ="rm")]

--- a/src/cli/commands/certificate.rs
+++ b/src/cli/commands/certificate.rs
@@ -19,6 +19,10 @@ pub(crate) enum Commands {
         #[clap(parse(from_os_str), value_name = "PRIVATE_KEY")]
         private_key_path: PathBuf,
     },
+
+    // List all certificates
+    List { },
+
     /// Remove a TLS certificate
     #[clap(alias ="delete")]
     #[clap(alias ="rm")]

--- a/src/cli/commands/channel.rs
+++ b/src/cli/commands/channel.rs
@@ -29,6 +29,10 @@ pub(crate) enum Commands {
         #[clap(long)]
         certificate_id: Option<String>,
     },
+
+    // List all channels
+    List { },
+
     /// Remove a channel
     #[clap(alias ="delete")]
     #[clap(alias ="rm")]

--- a/src/cli/commands/environment_variable.rs
+++ b/src/cli/commands/environment_variable.rs
@@ -17,6 +17,10 @@ pub(crate) enum Commands {
         /// The channel ID this environment variable will be bound to
         channel_id: String,
     },
+
+    // List all environment variables
+    List { },
+
     /// Remove an environment variable
     #[clap(alias ="delete")]
     #[clap(alias ="rm")]

--- a/src/cli/commands/revision.rs
+++ b/src/cli/commands/revision.rs
@@ -12,4 +12,7 @@ pub(crate) enum Commands {
         /// The revision number uploaded to Bindle
         revision_number: String,
     },
+
+    // List all revisions
+    List { }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -114,6 +114,11 @@ impl Cli {
                 println!("IMPORTANT: save this App ID for later - you will need it to update and/or delete the App");
             }
 
+            Commands::App(AppCommands::List { }) => {
+                let apps = hippo_client.list_apps().await?;
+                println!("{:?}", apps.apps);
+            }
+
             Commands::App(AppCommands::Remove { id }) => {
                 hippo_client.remove_app(id.to_owned()).await?;
                 println!("Removed App {}", id);
@@ -132,6 +137,11 @@ impl Cli {
                     .await?;
                 println!("Added Certificate {} (ID = '{}')", name, id);
                 println!("IMPORTANT: save this Certificate ID for later - you will need it to update and/or delete the Certificate");
+            }
+
+            Commands::Certificate(CertificateCommands::List { }) => {
+                let certificates = hippo_client.list_certificates().await?;
+                println!("{:?}", certificates.certificates);
             }
 
             Commands::Certificate(CertificateCommands::Remove { id }) => {
@@ -170,6 +180,11 @@ impl Cli {
                 println!("IMPORTANT: save this Channel ID for later - you will need it to update and/or delete the Channel");
             }
 
+            Commands::Channel(ChannelCommands::List { }) => {
+                let channels = hippo_client.list_channels().await?;
+                println!("{:?}", channels.channels);
+            }
+
             Commands::Channel(ChannelCommands::Remove { id }) => {
                 hippo_client.remove_channel(id.to_owned()).await?;
                 println!("Removed Channel {}", id);
@@ -189,6 +204,11 @@ impl Cli {
                     .await?;
                 println!("Added Environment Variable {} (ID = '{}')", key, id);
                 println!("IMPORTANT: save this Environment Variable ID for later - you will need it to update and/or delete the Environment Variable");
+            }
+
+            Commands::Env(EnvCommands::List { }) => {
+                let envs = hippo_client.list_environmentvariables().await?;
+                println!("{:?}", envs.environment_variables);
             }
 
             Commands::Env(EnvCommands::Remove { id }) => {
@@ -272,6 +292,11 @@ impl Cli {
                     .add_revision(app_storage_id.to_owned(), revision_number.to_owned())
                     .await?;
                 println!("Added Revision {}", revision_number);
+            }
+
+            Commands::Revision(RevisionCommands::List {}) => {
+                let revisions = hippo_client.list_revisions().await?;
+                println!("{:?}", revisions.revisions);
             }
 
             Commands::Whoami {} => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -116,7 +116,7 @@ impl Cli {
 
             Commands::App(AppCommands::List { }) => {
                 let apps = hippo_client.list_apps().await?;
-                println!("{:?}", apps.apps);
+                println!("{}", serde_json::to_string_pretty(&apps.apps)?);
             }
 
             Commands::App(AppCommands::Remove { id }) => {
@@ -141,7 +141,7 @@ impl Cli {
 
             Commands::Certificate(CertificateCommands::List { }) => {
                 let certificates = hippo_client.list_certificates().await?;
-                println!("{:?}", certificates.certificates);
+                println!("{}", serde_json::to_string_pretty(&certificates.certificates)?);
             }
 
             Commands::Certificate(CertificateCommands::Remove { id }) => {
@@ -182,7 +182,7 @@ impl Cli {
 
             Commands::Channel(ChannelCommands::List { }) => {
                 let channels = hippo_client.list_channels().await?;
-                println!("{:?}", channels.channels);
+                println!("{}", serde_json::to_string_pretty(&channels.channels)?);
             }
 
             Commands::Channel(ChannelCommands::Remove { id }) => {
@@ -208,7 +208,7 @@ impl Cli {
 
             Commands::Env(EnvCommands::List { }) => {
                 let envs = hippo_client.list_environmentvariables().await?;
-                println!("{:?}", envs.environment_variables);
+                println!("{}", serde_json::to_string_pretty(&envs.environment_variables)?);
             }
 
             Commands::Env(EnvCommands::Remove { id }) => {
@@ -296,7 +296,7 @@ impl Cli {
 
             Commands::Revision(RevisionCommands::List {}) => {
                 let revisions = hippo_client.list_revisions().await?;
-                println!("{:?}", revisions.revisions);
+                println!("{}", serde_json::to_string_pretty(&revisions.revisions)?);
             }
 
             Commands::Whoami {} => {

--- a/src/hippo/client.rs
+++ b/src/hippo/client.rs
@@ -1,19 +1,19 @@
 use std::collections::HashMap;
 
 use hippo_openapi::apis::account_api::{api_account_createtoken_post, api_account_post};
-use hippo_openapi::apis::app_api::{api_app_id_delete, api_app_post};
-use hippo_openapi::apis::certificate_api::{api_certificate_id_delete, api_certificate_post};
-use hippo_openapi::apis::channel_api::{api_channel_id_delete, api_channel_post};
+use hippo_openapi::apis::app_api::{api_app_get, api_app_id_delete, api_app_post};
+use hippo_openapi::apis::certificate_api::{api_certificate_get, api_certificate_id_delete, api_certificate_post};
+use hippo_openapi::apis::channel_api::{api_channel_get, api_channel_id_delete, api_channel_post};
 use hippo_openapi::apis::configuration::{ApiKey, Configuration};
 use hippo_openapi::apis::environment_variable_api::{
-    api_environmentvariable_id_delete, api_environmentvariable_post,
+    api_environmentvariable_get, api_environmentvariable_id_delete, api_environmentvariable_post,
 };
-use hippo_openapi::apis::revision_api::api_revision_post;
+use hippo_openapi::apis::revision_api::{api_revision_get, api_revision_post};
 use hippo_openapi::apis::Error;
 use hippo_openapi::models::{
     ChannelRevisionSelectionStrategy, CreateAccountCommand, CreateAppCommand,
     CreateCertificateCommand, CreateChannelCommand, CreateEnvironmentVariableCommand,
-    CreateTokenCommand, RegisterRevisionCommand, TokenInfo,
+    CreateTokenCommand, RegisterRevisionCommand, TokenInfo, RevisionsVm, AppsVm, CertificatesVm, ChannelsVm, EnvironmentVariablesVm,
 };
 
 use reqwest::header;
@@ -105,6 +105,10 @@ impl Client {
             .map_err(format_response_error)
     }
 
+    pub async fn list_apps(&self) -> anyhow::Result<AppsVm> {
+        api_app_get(&self.configuration).await.map_err(format_response_error)
+    }
+
     pub async fn add_certificate(
         &self,
         name: String,
@@ -121,6 +125,10 @@ impl Client {
         )
         .await
         .map_err(format_response_error)
+    }
+
+    pub async fn list_certificates(&self) -> anyhow::Result<CertificatesVm> {
+        api_certificate_get(&self.configuration).await.map_err(format_response_error)
     }
 
     pub async fn remove_certificate(&self, id: String) -> anyhow::Result<()> {
@@ -153,6 +161,10 @@ impl Client {
             .map_err(format_response_error)
     }
 
+    pub async fn list_channels(&self) -> anyhow::Result<ChannelsVm> {
+        api_channel_get(&self.configuration).await.map_err(format_response_error)
+    }
+
     pub async fn remove_channel(&self, id: String) -> anyhow::Result<()> {
         api_channel_id_delete(&self.configuration, &id)
             .await
@@ -177,6 +189,10 @@ impl Client {
         .map_err(format_response_error)
     }
 
+    pub async fn list_environmentvariables(&self) -> anyhow::Result<EnvironmentVariablesVm> {
+        api_environmentvariable_get(&self.configuration).await.map_err(format_response_error)
+    }
+
     pub async fn remove_environment_variable(&self, id: String) -> anyhow::Result<()> {
         api_environmentvariable_id_delete(&self.configuration, &id)
             .await
@@ -197,6 +213,10 @@ impl Client {
         )
         .await
         .map_err(format_response_error)
+    }
+
+    pub async fn list_revisions(&self) -> anyhow::Result<RevisionsVm> {
+        api_revision_get(&self.configuration).await.map_err(format_response_error)
     }
 }
 


### PR DESCRIPTION
relies on #121

This is a rough implementation of `hippo app list`, `hippo channel list`, `hippo env list`, etc. It lists ALL objects of each resource. Eventually this will only be an endpoint available to administrators once https://github.com/deislabs/hippo/issues/575 is implemented, but until then it's a handy introspection tool for developers/administrators.

note that several commands do not work due to https://github.com/fermyon/hippo-openapi/issues/6. Once that's fixed, commands like `hippo channel list` and `hippo app list` should work.