### PR TITLE
WIP: implement `hippo deploy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Added Environment Variable HELLO (ID = 'c97f9855-d998-4dac-889b-11b553f53bea')
 IMPORTANT: save this Environment Variable ID for later - you will need it to update and/or delete the Environment Variable
 ```
 
+### Deploying an existing Bindle
+
+To automate the process, Hippo provides a command to automate the process of
+creating an application, channel, and registering a revision in one command:
+`hippo deploy`.
+
+Assuming you pushed a bindle with the ID `helloworld/1.0.0`:
+
+```console
+$ hippo deploy helloworld 1.0.0
+Deployed helloworld/1.0.0
+```
+
 ## Building from source
 
 ```console

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -16,6 +16,17 @@ pub(crate) enum Commands {
     #[clap(subcommand)]
     Certificate(certificate::Commands),
 
+    /// Deploy a Bindle ID
+    Deploy {
+        /// The storage ID of the Bindle
+        storage_id: String,
+        /// The revision number uploaded to Bindle
+        revision_number: String,
+        /// The domain name used to serve requests for this application
+        #[clap(short, long)]
+        domain: Option<String>,
+    },
+
     /// Add, update, and remove Channels
     #[clap(subcommand)]
     Channel(channel::Commands),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -175,6 +175,17 @@ impl Cli {
                 println!("Removed Channel {}", id);
             }
 
+            Commands::Deploy {
+                storage_id,
+                revision_number,
+                domain
+            } => {
+                let app_id = hippo_client.add_app(storage_id.to_owned(), storage_id.to_owned()).await?;
+                hippo_client.add_channel(app_id, "hippo-deploy".to_owned(), domain.to_owned(), ChannelRevisionSelectionStrategy::_0, None, None, None).await?;
+                hippo_client.add_revision(storage_id.to_owned(), revision_number.to_owned()).await?;
+                println!("Deployed {}/{}", storage_id, revision_number);
+            }
+
             Commands::Env(EnvCommands::Add {
                 key,
                 value,


### PR DESCRIPTION
How to test this:

```
$ spin bindle push --file spin.toml --bindle-server http://localhost:8080/v1
pushed: spin-docs/1.0.0
$ hippo deploy spin-docs 1.0.0
Deployed spin-docs/1.0.0
```

The application will then be served by the domain `hippo-deploy.spin-deploy.hippofactory.local`.