### PR TITLE
update authors to Fermyon Engineering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "hippo"
 version = "0.11.0"
 authors = [
-    "Ivan Towlson <ivan.towlson@fermyon.com>",
-    "Matt Fisher <matt.fisher@fermyon.com>"
+    "Fermyon Engineering <engineering@fermyon.com>"
 ]
 edition = "2018"
 


### PR DESCRIPTION
Changes the help text (and package info) from this:

```
$ hippo help | head -n 2
hippo 0.11.0
Ivan Towlson <ivan.towlson@fermyon.com>, Matt Fisher <matt.fisher@fermyon.com>
```

To this:

```
$ ./target/release/hippo help | head -n 2
hippo 0.11.0
Fermyon Engineering <engineering@fermyon.com>
```

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>