### PR TITLE
fix: warning about misuse of `anyhow!` macro

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -158,7 +158,7 @@ impl Cli {
                 certificate_id,
             }) => {
                 if range_rule.is_some() && revision_id.is_some() {
-                    anyhow::anyhow!("cannot specify both a range rule and a revision ID");
+                    anyhow::bail!("cannot specify both a range rule and a revision ID");
                 }
                 let revision_selection_strategy = match (range_rule, revision_id) {
                     (Some(_), None) => ChannelRevisionSelectionStrategy::UseRangeRule,


### PR DESCRIPTION
The `anyhow!` macro won't exit the function -- you need `bail!` for that.

Signed-off-by: Joel Dice <joel.dice@gmail.com>